### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ BUILD_IN_CONTAINER ?= true
 BUILD_IMAGE_VERSION := 0.12.0
 
 # Docker image info
-IMAGE_PREFIX ?= ghrc.io/credativ
+IMAGE_PREFIX ?= ghcr.io/credativ
 
 IMAGE_TAG := $(shell ./tools/image-tag)
 


### PR DESCRIPTION
Hi `credativ/vali`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used).
Please fix this typo and check your documentation for similar typos.