### PR TITLE
[CI Test] Bump golang version to 1.20.5

### DIFF
--- a/cmd/fluent-bit/Dockerfile
+++ b/cmd/fluent-bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3 as build
+FROM golang:1.20.5 as build
 COPY . /src/vali
 WORKDIR /src/vali
 RUN make clean && make BUILD_IN_CONTAINER=false fluent-bit-plugin

--- a/cmd/logcli/Dockerfile
+++ b/cmd/logcli/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3 as build
+FROM golang:1.20.5 as build
 
 ARG TOUCH_PROTOS
 COPY . /src/vali

--- a/cmd/migrate/Dockerfile
+++ b/cmd/migrate/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3 as build
+FROM golang:1.20.5 as build
 COPY . /src/vali
 WORKDIR /src/vali
 RUN make clean && make BUILD_IN_CONTAINER=false migrate

--- a/cmd/querytee/Dockerfile
+++ b/cmd/querytee/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3 as build
+FROM golang:1.20.5 as build
 
 ARG TOUCH_PROTOS
 COPY . /src/vali

--- a/cmd/querytee/Dockerfile.cross
+++ b/cmd/querytee/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=ghcr.io/credativ/vali-build-image:0.9.1
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t ghcr.io/credativ/valitail -f cmd/valitail/Dockerfile .
-FROM golang:1.20.3-alpine as goenv
+FROM golang:1.20.5-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/cmd/vali-canary/Dockerfile
+++ b/cmd/vali-canary/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3 as build
+FROM golang:1.20.5 as build
 # TOUCH_PROTOS signifies if we should touch the compiled proto files and thus not regenerate them.
 # This is helpful when file system timestamps can't be trusted with make
 ARG TOUCH_PROTOS

--- a/cmd/vali-canary/Dockerfile.cross
+++ b/cmd/vali-canary/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=ghcr.io/credativ/vali-build-image:0.12.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t ghcr.io/credativ/valitail -f cmd/valitail/Dockerfile .
-FROM golang:1.20.3-alpine as goenv
+FROM golang:1.20.5-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/cmd/vali/Dockerfile
+++ b/cmd/vali/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3 as build
+FROM golang:1.20.5 as build
 # TOUCH_PROTOS signifies if we should touch the compiled proto files and thus not regenerate them.
 # This is helpful when file system timestamps can't be trusted with make
 ARG TOUCH_PROTOS

--- a/cmd/vali/Dockerfile.cross
+++ b/cmd/vali/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=ghcr.io/credativ/vali-build-image:0.12.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t ghcr.io/credativ/vali -f cmd/vali/Dockerfile .
-FROM golang:1.20.3-alpine as goenv
+FROM golang:1.20.5-alpine as goenv
 RUN go env GOARCH > /goarch && \
     go env GOARM > /goarm
 

--- a/cmd/valitail/Dockerfile
+++ b/cmd/valitail/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3-buster as build
+FROM golang:1.20.5-buster as build
 # TOUCH_PROTOS signifies if we should touch the compiled proto files and thus not regenerate them.
 # This is helpful when file system timestamps can't be trusted with make
 ARG TOUCH_PROTOS

--- a/cmd/valitail/Dockerfile.arm32
+++ b/cmd/valitail/Dockerfile.arm32
@@ -1,4 +1,4 @@
-FROM golang:1.20.3 as build
+FROM golang:1.20.5 as build
 # TOUCH_PROTOS signifies if we should touch the compiled proto files and thus not regenerate them.
 # This is helpful when file system timestamps can't be trusted with make
 ARG TOUCH_PROTOS

--- a/cmd/valitail/Dockerfile.cross
+++ b/cmd/valitail/Dockerfile.cross
@@ -2,7 +2,7 @@ ARG BUILD_IMAGE=ghcr.io/credativ/vali-build-image:0.12.0
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t ghcr.io/credativ/valitail -f cmd/valitail/Dockerfile .
-FROM golang:1.20.3-alpine as goenv
+FROM golang:1.20.5-alpine as goenv
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 

--- a/vali-build-image/Dockerfile
+++ b/vali-build-image/Dockerfile
@@ -20,10 +20,10 @@ RUN apk add --no-cache docker-cli
 # Error:
 #	github.com/fatih/faillint@v1.5.0 requires golang.org/x/tools@v0.0.0-20200207224406-61798d64f025
 #   (not golang.org/x/tools@v0.0.0-20190918214920-58d531046acd from golang.org/x/tools/cmd/goyacc@58d531046acdc757f177387bc1725bfa79895d69)
-FROM docker.io/library/golang:1.20.3 as faillint
+FROM docker.io/library/golang:1.20.5 as faillint
 RUN go install github.com/fatih/faillint@v1.11.0
 
-FROM docker.io/library/golang:1.20.3-buster
+FROM docker.io/library/golang:1.20.5-buster
 RUN apt-get update && \
     apt-get install -qy \
     musl gnupg \


### PR DESCRIPTION
Another testrun for #19 . Branch name contains dots.