### PR TITLE
Build logcli binary in CI

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -1,0 +1,18 @@
+This is release vVERSION of Vali.
+
+Vali is a fork of Loki 2.2.1 under the Apache 2.0 License.
+It is currently limited to maintenance and security updates.
+
+### Notable changes
+
+* INSERT CHANGES HERE
+
+### Installation
+
+The components of Vali are currently distributed as container images.
+
+* `ghcr.io/credativ/vali:vVERSION`
+  https://github.com/credativ/vali/pkgs/container/vali
+
+* `ghcr.io/credativ/valitail:vVERSION`
+  https://github.com/credativ/vali/pkgs/container/valitail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,3 +52,26 @@ jobs:
           name: logcli_${{ matrix.arch }}
           path: logcli_${{ matrix.arch }}.zip
           retention-days: 3
+
+  release:
+    runs-on: ubuntu-latest
+    needs: logcli
+    if: startsWith(github.event.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+
+      - name: Create draft release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "artifacts/logcli_*/logcli_*.zip"
+          artifactErrorsFailBuild: true
+          bodyFile: ".github/release_template.md"
+          draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - "main"
+    tags:
+      - "v*"
+  pull_request:
+
+jobs:
+  logcli:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.21.3
+
+      - name: Install package dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make protobuf-compiler zip
+
+      - name: Install Go dependencies
+        run: |
+          go install github.com/golang/protobuf/protoc-gen-go@v1.3.0
+          go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.2.1
+
+      - name: Build logcli
+        run: make BUILD_IN_CONTAINER=false logcli
+
+      - name: Zip logcli
+        run: zip --junk-paths logcli_amd64.zip cmd/logcli/logcli
+
+      - name: Upload logcli as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: logcli_amd64
+          path: logcli_amd64.zip
+          retention-days: 3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -32,15 +35,20 @@ jobs:
           go install github.com/golang/protobuf/protoc-gen-go@v1.3.0
           go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.2.1
 
+      - name: Pre-generate code
+        run: make BUILD_IN_CONTAINER=false generate
+
       - name: Build logcli
         run: make BUILD_IN_CONTAINER=false logcli
+        env:
+          GOARCH: ${{ matrix.arch }}
 
       - name: Zip logcli
-        run: zip --junk-paths logcli_amd64.zip cmd/logcli/logcli
+        run: zip --junk-paths logcli_${{ matrix.arch }}.zip cmd/logcli/logcli
 
       - name: Upload logcli as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: logcli_amd64
-          path: logcli_amd64.zip
+          name: logcli_${{ matrix.arch }}
+          path: logcli_${{ matrix.arch }}.zip
           retention-days: 3

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,8 @@ touch-protobuf-sources:
 		touch $$def; \
 	done
 
+generate: $(VALITAIL_GENERATED_FILE)
+
 ##########
 # Logcli #
 ##########


### PR DESCRIPTION
Build logcli binary in the CI for amd64 and arm64, create a draft release for tags and attach the binaries to the release.